### PR TITLE
chore:update AGENTS.md with guildelines when to use agent-session

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -182,8 +182,8 @@ The `workflow.json` file must follow this structure:
 - Include appropriate `stepMaxDurationMinutes` for each step
 - Define triggers (automatic events or manual slash commands)
 - Include agent references in `refs.agents` array
-- **Copy instruction content from corresponding `.md` files** into each step's `instruction` field
 - Flow connections must match the sequence described in README
+- Set `instruction` to `null` for infrastructure steps (git.clone, repo.identify) — prompt content will be synced separately
 
 **Implementation Process:**
 
@@ -193,7 +193,7 @@ The `workflow.json` file must follow this structure:
    - `name`: Human-readable step name
    - `action`: `agent.run`, `agent.session`, `git.clone`, etc.
    - `params`: Step-specific parameters
-   - `instruction`: Copy content from the corresponding `{step-id}.md` file
+   - `instruction`: Set to `null` initially (will be synced from `.md` files)
    - `stepMaxDurationMinutes`: Based on README estimates
 
 2. **Create flow array**: Define connections between steps based on README workflow sequence
@@ -202,11 +202,17 @@ The `workflow.json` file must follow this structure:
 
 4. **Add agent references**: List all agents used in `refs.agents`
 
+5. **Sync prompt content into workflow.json** using the sync script:
+
+```bash
+python3 scripts/sync-prompts.py <playbook-directory>
+```
+
+This automatically copies content from each `{step-id}.md` file into the matching step's `instruction` field in `workflow.json`, handling JSON escaping correctly.
+
 **Validation:**
 
-- Verify every prompt file has a corresponding step
-- Verify every step has a corresponding prompt file
-- Verify step IDs match prompt filenames exactly
+- Run `python3 scripts/sync-prompts.py <playbook-directory>` — it reports any mismatches
 - Verify flow matches README sequence
 - Verify triggers match README description
 
@@ -255,19 +261,25 @@ The `workflow.json` file must follow this structure:
 ### Updating Prompts
 
 1. **Edit the prompt file** (e.g., `code-review.md`)
-2. **Update workflow.json** to match:
-   - Find the step with matching `id` (e.g., `"id": "code-review"`)
-   - Update the `instruction` field with content from the `.md` file
-   - Maintain exact filename-to-ID matching
+2. **Run the sync script** to update workflow.json automatically:
+
+```bash
+python3 scripts/sync-prompts.py <playbook-directory>
+```
 
 **Example:**
 
 ```bash
-# User edits: code-review/code-review.md
-# Agent must update: code-review/workflow.json
-# Find step: {"id": "code-review", ...}
-# Update: "instruction": "[content from code-review.md]"
+# Edit the prompt file
+vim code-review/code-review.md
+
+# Sync all prompts into workflow.json
+python3 scripts/sync-prompts.py code-review
 ```
+
+The script reads all `*.md` files in the playbook directory (excluding `README.md`), matches each to a step in `workflow.json` by filename == step ID, and updates the `instruction` field with the file content. It handles JSON escaping automatically and reports any mismatches between `.md` files and steps.
+
+**Important:** Always use this script instead of manually copying prompt content into workflow.json. Manual copying is error-prone due to JSON string escaping (newlines, quotes, etc.).
 
 ### Adding New Steps
 

--- a/scripts/sync-prompts.py
+++ b/scripts/sync-prompts.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Sync prompt .md files into workflow.json instruction fields.
+
+Reads all *.md files in a playbook directory (excluding README.md),
+matches them to steps in workflow.json by filename == step ID,
+and updates each step's instruction field with the file content.
+
+Usage:
+    python3 scripts/sync-prompts.py <playbook-directory>
+
+Examples:
+    python3 scripts/sync-prompts.py break-down-ticket
+    python3 scripts/sync-prompts.py code-review
+    python3 scripts/sync-prompts.py requirements-document-generation
+"""
+
+import json
+import glob
+import os
+import sys
+
+
+def sync_prompts(playbook_dir):
+    workflow_path = os.path.join(playbook_dir, "workflow.json")
+
+    if not os.path.isfile(workflow_path):
+        print(f"Error: {workflow_path} not found")
+        sys.exit(1)
+
+    # Load workflow.json
+    with open(workflow_path, "r") as f:
+        workflow = json.load(f)
+
+    # Collect all prompt .md files (exclude README.md)
+    prompts = {}
+    for md_file in sorted(glob.glob(os.path.join(playbook_dir, "*.md"))):
+        basename = os.path.basename(md_file)
+        if basename == "README.md":
+            continue
+        step_id = basename.removesuffix(".md")
+        with open(md_file, "r") as f:
+            prompts[step_id] = f.read().rstrip("\n")
+
+    if not prompts:
+        print(f"No prompt .md files found in {playbook_dir}")
+        sys.exit(1)
+
+    # Match prompts to steps and update
+    steps = workflow["workflow"]["definition"]["steps"]
+    step_ids = {step["id"] for step in steps}
+
+    updated = []
+    unmatched_prompts = []
+    unmatched_steps = []
+
+    for step_id, content in prompts.items():
+        if step_id not in step_ids:
+            unmatched_prompts.append(step_id)
+            continue
+        for step in steps:
+            if step["id"] == step_id:
+                step["instruction"] = content
+                updated.append(step_id)
+                break
+
+    # Check for agent steps that have no matching .md file
+    for step in steps:
+        if step.get("instruction") is not None and step["id"] not in prompts:
+            unmatched_steps.append(step["id"])
+
+    # Write back
+    with open(workflow_path, "w") as f:
+        json.dump(workflow, f, indent=2)
+        f.write("\n")
+
+    # Report results
+    print(f"Synced {len(updated)} prompt(s) into {workflow_path}:")
+    for step_id in updated:
+        print(f"  {step_id}.md -> step '{step_id}'")
+
+    if unmatched_prompts:
+        print(f"\nWarning: .md files with no matching step in workflow.json:")
+        for step_id in unmatched_prompts:
+            print(f"  {step_id}.md")
+
+    if unmatched_steps:
+        print(f"\nWarning: steps with instructions but no matching .md file:")
+        for step_id in unmatched_steps:
+            print(f"  {step_id}")
+
+    if not unmatched_prompts and not unmatched_steps:
+        print("\nAll prompts and steps are in sync.")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python3 scripts/sync-prompts.py <playbook-directory>")
+        print("Example: python3 scripts/sync-prompts.py break-down-ticket")
+        sys.exit(1)
+
+    sync_prompts(sys.argv[1])


### PR DESCRIPTION
<!-- overcut:pr-description:start -->
## Summary
This PR introduces a sync script and documentation updates so prompt instructions in `workflow.json` stay aligned with their `.md` counterparts. It clarifies when to use `agent.run` versus `agent.session`, positioning session mode as a coordinator-driven execution pattern for multi-step or verification-heavy workflows.

## Changes
- **Documentation**: Added instructions to set `instruction` to `null` for infrastructure steps and rely on the sync script for prompt content.
- **Documentation**: Documented the new `scripts/sync-prompts.py` workflow, including usage, validation steps, and rationale for coordinator-led sessions.
- **Documentation**: Expanded the agent execution guidance to distinguish single-pass `agent.run` steps from coordinated `agent.session` use cases.
- **Features**: Added `scripts/sync-prompts.py` to automatically copy prompt `.md` content into `workflow.json`, reporting mismatches and handling JSON escaping.

## Commits
- e3ea128 feat: update agent documentation and requirements workflow with script to auto update json with prompts

## Testing
- [ ] Review the rendered AGENTS.md to ensure the new coordinator guidance displays correctly.
- [ ] Verify internal and external references to the “Agent Session” section still point to the updated heading.
- [ ] Run `python3 scripts/sync-prompts.py <playbook-directory>` to ensure prompts sync into `workflow.json` without mismatches.
<!-- overcut:pr-description:end -->