### PR TITLE
docs: update terminology from use cases to workflows and templates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides instructions for AI agents working with the Overcut Playbooks repository. It contains essential information for creating, updating, and maintaining playbooks (workflow use cases).
+This file provides instructions for AI agents working with the Overcut Playbooks repository. It contains essential information for creating, updating, and maintaining playbooks (workflow templates).
 
 ## 📋 Project Overview
 

--- a/create-pr-from-design/README.md
+++ b/create-pr-from-design/README.md
@@ -199,7 +199,7 @@ Edit step **Finalize PR** PR description template to:
 - Check that tests are comprehensive and passing
 - Verify lint/format checks passed
 - Request review from appropriate team members
-- Trigger automated code review by using the [Code Review](../code-review/) Use Case
+- Trigger automated code review by using the [Code Review](../code-review/) workflow
 
 **Customizing for your team:**
 


### PR DESCRIPTION
Closes #1983

<!-- overcut:pr-description:start -->
## Summary

This PR updates playbook documentation terminology to use the current workflow/template language instead of the older "use case" wording. It keeps the docs aligned with the platform's current naming and reduces confusion for readers following PR and agent guidance.

## Changes

- **Documentation**: Updated `AGENTS.md` to describe playbooks in terms of workflow templates instead of workflow use cases
- **Documentation**: Updated `create-pr-from-design/README.md` to refer to the Code Review playbook as a workflow instead of a use case

## Related Issues

- Closes #1983

## Commits

- 0133305 docs: update terminology from use cases to workflows and templates

## Testing

- [ ] Verify the updated terminology in `AGENTS.md` is accurate and consistent with current product language
- [ ] Verify the Code Review reference in `create-pr-from-design/README.md` points to the correct workflow path and reads naturally in context
- [ ] Spot-check nearby documentation for any remaining "use case" terminology that should stay unchanged or be updated separately
<!-- overcut:pr-description:end -->